### PR TITLE
[Bug fix] Change item.selected after call selected().

### DIFF
--- a/src/plugins/Selection.plugin.ts
+++ b/src/plugins/Selection.plugin.ts
@@ -295,10 +295,10 @@ export default function Selection(options: Options = {}) {
       for (const itemId in items) {
         const item = items[itemId];
         if (currentSelect.selecting['chart-timeline-items-row-items'].includes(item.id)) {
-          item.selected = true;
           if (typeof item.selected === 'undefined' || !item.selected) {
             options.selected(item, 'chart-timeline-items-row-item');
           }
+          item.selected = true;
         } else if (addToPrevious && previousSelect.selected['chart-timeline-items-row-items'].includes(item.id)) {
           item.selected = true;
         } else {


### PR DESCRIPTION
type and value check of item.selected is meaningless after item.selected = true;
This cause selected() function is not emitted after user selects timeline-items-row-item.

